### PR TITLE
Switch to awsvpc network work

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -ex
+
 APP_NAME=`echo ${GITHUB_REPO} | sed 's/_/-/g'`
 APP_NAME=`echo ${APP_NAME} | sed 's/-//g'`
 APP_NAME=`echo ${APP_NAME} | cut -c1-15`

--- a/params.sh
+++ b/params.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 KEYS=`awk -F"=" '{print $1}' .env.sample`
-printf "\n        Environment:\n" > env.yaml
+#printf "\n        Environment:\n" > env.yaml
 for KEY in $KEYS
 do
   PARAM=`aws ssm get-parameters --name ${S3_APP_BUCKET_NAME}.${KEY} --with-decryption --query Parameters[0].Value`

--- a/post_build.sh
+++ b/post_build.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -ex
+
 if [ "$DEPLOY_ENVIRONMENT" = "development" ] || \
    [ "$DEPLOY_ENVIRONMENT" = "staging" ] || \
    [ "$DEPLOY_ENVIRONMENT" = "feature" ] || \

--- a/service.yaml
+++ b/service.yaml
@@ -185,6 +185,13 @@ ENVIRONMENT_VARIABLES
           Ref: ECSTG
       Role:
         Ref: ECSServiceRole
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          Subnets:
+            - Fn::ImportValue:
+                Fn::Sub: "${EnvironmentName}-PrivateSubnet1"
+            - Fn::ImportValue:
+                Fn::Sub: "${EnvironmentName}-PrivateSubnet2"
   ApiGateway:
     Type: AWS::ApiGateway::RestApi
     Condition: IsApiGatewayNeeded

--- a/service.yaml
+++ b/service.yaml
@@ -91,12 +91,6 @@ Resources:
     Properties:
       LogGroupName: !Sub "${EnvironmentName}-APP_NAME"
       RetentionInDays: 14
-  CloudwatchLogsGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      LogGroupName:
-        Fn::Sub: "ECSLogGroup-${AWS::StackName}"
-      RetentionInDays: 14
   ALB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:

--- a/service.yaml
+++ b/service.yaml
@@ -180,19 +180,18 @@ ENVIRONMENT_VARIABLES
       - ALBListener
     Properties:
       Cluster:
-        Fn::ImportValue:
-          Fn::Sub: "${EnvironmentName}-ECSCluster"
+        Fn::ImportValue: !Sub '${EnvironmentName}-ECSCluster'
       DesiredCount: DESIRED_COUNT
-      TaskDefinition: !Ref: TaskDefinition
+      TaskDefinition: !Ref 'TaskDefinition'
       LoadBalancers:
       - ContainerName: APP_NAME
         ContainerPort: !Ref 'ContainerPort'
-        TargetGroupArn: !Ref: TargetGroup
+        TargetGroupArn: !Ref 'TargetGroup'
       NetworkConfiguration:
         AwsvpcConfiguration:
           Subnets:
-            - Fn::ImportValue: Fn::Sub: "${EnvironmentName}-PrivateSubnet1"
-            - Fn::ImportValue: Fn::Sub: "${EnvironmentName}-PrivateSubnet2"
+            - Fn::ImportValue: !Sub '${EnvironmentName}-PrivateSubnet1'
+            - Fn::ImportValue: !Sub '${EnvironmentName}-PrivateSubnet2'
   ApiGateway:
     Type: AWS::ApiGateway::RestApi
     Condition: IsApiGatewayNeeded

--- a/service.yaml
+++ b/service.yaml
@@ -42,6 +42,7 @@ Resources:
     Properties:
       #The Family name will be used along with ECS_CLUSTER_NAME to prepare the stack name. It should be of Format abb-cdd-sd
       Family: APP_NAME-BUILD_SCOPE
+      NetworkMode: awsvpc
       ContainerDefinitions:
       - Name: APP_NAME
         Cpu: ECS_CPU_COUNT
@@ -62,10 +63,8 @@ Resources:
         PortMappings:
         - ContainerPort: 9000
           HostPort: 0
-        Links:
-          - xraydaemon
         Environment:
-        - Name: AWS_XRAY_DAEMON_ADDRESS
+        - Name: XXXAWS_XRAY_DAEMON_ADDRESS
           Value: 'xraydaemon:2000'
 ENVIRONMENT_VARIABLES
   ECSServiceRole:

--- a/service.yaml
+++ b/service.yaml
@@ -65,7 +65,7 @@ Resources:
               Ref: AWS::Region
             awslogs-stream-prefix: !Sub "${EnvironmentName}-APP_NAME"
         PortMappings:
-        - ContainerPort: !Ref 'ContainerPort'
+          - ContainerPort: !Ref 'ContainerPort'
         Environment:
         - Name: XXXAWS_XRAY_DAEMON_ADDRESS
           Value: 'xraydaemon:2000'
@@ -84,9 +84,7 @@ ENVIRONMENT_VARIABLES
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: ECS Security Group
-      VpcId:
-        Fn::ImportValue:
-           Fn::Sub:  "${EnvironmentName}-VPC"
+      VpcId: Fn::ImportValue: !Sub '${EnvironmentName}-VPC'
       SecurityGroupIngress:
         # Only allow inbound access to ECS from the same VPC
         - IpProtocol: tcp
@@ -107,14 +105,11 @@ ENVIRONMENT_VARIABLES
         - Key: idle_timeout.timeout_seconds
           Value: '30'
       Subnets:
-        - Fn::ImportValue:
-            Fn::Sub: "${EnvironmentName}-PublicSubnet1"
-        - Fn::ImportValue:
-            Fn::Sub: "${EnvironmentName}-PublicSubnet2"
+        - Fn::ImportValue: !Sub '${EnvironmentName}-PublicSubnet1'
+        - Fn::ImportValue: !Sub '${EnvironmentName}-PublicSubnet2'
       SecurityGroups:
       - Ref: ECSSecurityGroup
-      - Fn::ImportValue:
-          Fn::Sub: "${EnvironmentName}-ECSHostSecurityGroup"
+      - Fn::ImportValue: !Sub '${EnvironmentName}-ECSHostSecurityGroup'
   ALBListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     DependsOn: ECSServiceRole
@@ -179,16 +174,17 @@ ENVIRONMENT_VARIABLES
       - ALB
       - ALBListener
     Properties:
-      Cluster:
-        Fn::ImportValue: !Sub '${EnvironmentName}-ECSCluster'
+      Cluster: Fn::ImportValue: !Sub '${EnvironmentName}-ECSCluster'
       DesiredCount: DESIRED_COUNT
       TaskDefinition: !Ref 'TaskDefinition'
       LoadBalancers:
-      - ContainerName: APP_NAME
-        ContainerPort: !Ref 'ContainerPort'
-        TargetGroupArn: !Ref 'TargetGroup'
+        - ContainerName: APP_NAME
+          ContainerPort: !Ref 'ContainerPort'
+          TargetGroupArn: !Ref 'TargetGroup'
       NetworkConfiguration:
         AwsvpcConfiguration:
+          SecurityGroup:
+            - Fn::ImportValue: !Sub '${EnvironmentName}-ECSHostSecurityGroup'
           Subnets:
             - Fn::ImportValue: !Sub '${EnvironmentName}-PrivateSubnet1'
             - Fn::ImportValue: !Sub '${EnvironmentName}-PrivateSubnet2'

--- a/service.yaml
+++ b/service.yaml
@@ -129,7 +129,7 @@ ENVIRONMENT_VARIABLES
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     DependsOn: ALB
     Properties:
-      Name: !Sub "${EnvironmentName}-APP_NAME"
+      Name: !Sub "${EnvironmentName}-APP_NAME2"
       HealthCheckIntervalSeconds: 10
       HealthCheckPath: /health
       HealthCheckProtocol: HTTP

--- a/service.yaml
+++ b/service.yaml
@@ -62,6 +62,11 @@ Resources:
         PortMappings:
         - ContainerPort: 9000
           HostPort: 0
+        Links:
+          - xraydaemon
+        Environment:
+        - Name: AWS_XRAY_DAEMON_ADDRESS
+          Value: 'xraydaemon:2000'
         ENVIRONMENT_VARIABLES
   ECSServiceRole:
     Type: AWS::IAM::Role

--- a/service.yaml
+++ b/service.yaml
@@ -62,7 +62,6 @@ Resources:
             awslogs-stream-prefix: !Sub "${EnvironmentName}-APP_NAME"
         PortMappings:
         - ContainerPort: 9000
-          HostPort: 0
         Environment:
         - Name: XXXAWS_XRAY_DAEMON_ADDRESS
           Value: 'xraydaemon:2000'

--- a/service.yaml
+++ b/service.yaml
@@ -66,8 +66,8 @@ Resources:
           - xraydaemon
         Environment:
         - Name: AWS_XRAY_DAEMON_ADDRESS
-          Value: "xraydaemon:2000"
-        ENVIRONMENT_VARIABLES
+          Value: 'xraydaemon:2000'
+ENVIRONMENT_VARIABLES
   ECSServiceRole:
     Type: AWS::IAM::Role
     Properties:

--- a/service.yaml
+++ b/service.yaml
@@ -135,6 +135,7 @@ ENVIRONMENT_VARIABLES
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
+      TargetType: ip
       Port: 80
       Protocol: HTTP
       UnhealthyThresholdCount: 2

--- a/service.yaml
+++ b/service.yaml
@@ -10,7 +10,7 @@ Parameters:
     Default: IMAGE_TAG
   ContainerPort:
     Type: Number
-    Default: 80
+    Default: 9000
     Description: What port number the application inside the docker container is binding to
   EnvironmentName:
     Type: String
@@ -140,7 +140,7 @@ ENVIRONMENT_VARIABLES
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
       TargetType: ip
-      Port: 80
+      Port: !Ref 'ContainerPort'
       Protocol: HTTP
       UnhealthyThresholdCount: 2
       VpcId:

--- a/service.yaml
+++ b/service.yaml
@@ -120,12 +120,12 @@ ENVIRONMENT_VARIABLES
       DefaultActions:
       - Type: forward
         TargetGroupArn:
-          Ref: ECSTG
+          Ref: TargetGroup
       LoadBalancerArn:
         Ref: ALB
       Port: '443'
       Protocol: HTTPS
-  ECSTG:
+  TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     DependsOn: ALB
     Properties:
@@ -182,7 +182,7 @@ ENVIRONMENT_VARIABLES
       - ContainerName: APP_NAME
         ContainerPort: 9000
         TargetGroupArn:
-          Ref: ECSTG
+          Ref: TargetGroup
       NetworkConfiguration:
         AwsvpcConfiguration:
           Subnets:
@@ -359,7 +359,7 @@ OPEN_API_SPEC
           "Fn::GetAtt": [ ALB, LoadBalancerFullName ]
       - Name: TargetGroup
         Value:
-          "Fn::GetAtt": [ ECSTG, TargetGroupFullName ]
+          "Fn::GetAtt": [ TargetGroup, TargetGroupFullName ]
       ComparisonOperator: LessThanThreshold
       MetricName: HealthyHostCount
   UnhealthyHostAlarm:
@@ -380,7 +380,7 @@ OPEN_API_SPEC
           "Fn::GetAtt": [ ALB, LoadBalancerFullName ]
       - Name: TargetGroup
         Value:
-          "Fn::GetAtt": [ ECSTG, TargetGroupFullName ]
+          "Fn::GetAtt": [ TargetGroup, TargetGroupFullName ]
       ComparisonOperator: GreaterThanOrEqualToThreshold
       MetricName: UnHealthyHostCount
   AlarmNotificationTopic:

--- a/service.yaml
+++ b/service.yaml
@@ -84,7 +84,9 @@ ENVIRONMENT_VARIABLES
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: ECS Security Group
-      VpcId: Fn::ImportValue: !Sub '${EnvironmentName}-VPC'
+      VpcId:
+        Fn::ImportValue:
+          !Sub '${EnvironmentName}-VPC'
       SecurityGroupIngress:
         # Only allow inbound access to ECS from the same VPC
         - IpProtocol: tcp
@@ -94,7 +96,7 @@ ENVIRONMENT_VARIABLES
   ContainerLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "${EnvironmentName}-APP_NAME"
+      LogGroupName: !Sub '${EnvironmentName}-APP_NAME'
       RetentionInDays: 14
   ALB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer

--- a/service.yaml
+++ b/service.yaml
@@ -66,7 +66,7 @@ Resources:
           - xraydaemon
         Environment:
         - Name: AWS_XRAY_DAEMON_ADDRESS
-          Value: 'xraydaemon:2000'
+          Value: "xraydaemon:2000"
         ENVIRONMENT_VARIABLES
   ECSServiceRole:
     Type: AWS::IAM::Role

--- a/service.yaml
+++ b/service.yaml
@@ -10,7 +10,7 @@ Parameters:
     Default: IMAGE_TAG
   ContainerPort:
     Type: Number
-    Default: 9000
+    Default: 80
     Description: What port number the application inside the docker container is binding to
   EnvironmentName:
     Type: String

--- a/service.yaml
+++ b/service.yaml
@@ -182,8 +182,6 @@ ENVIRONMENT_VARIABLES
         ContainerPort: 9000
         TargetGroupArn:
           Ref: ECSTG
-      Role:
-        Ref: ECSServiceRole
       NetworkConfiguration:
         AwsvpcConfiguration:
           Subnets:

--- a/service.yaml
+++ b/service.yaml
@@ -129,7 +129,7 @@ ENVIRONMENT_VARIABLES
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     DependsOn: ALB
     Properties:
-      Name: !Sub "${EnvironmentName}-APP_NAME2"
+      Name: !Sub "${EnvironmentName}-APP_NAME"
       HealthCheckIntervalSeconds: 10
       HealthCheckPath: /health
       HealthCheckProtocol: HTTP

--- a/service.yaml
+++ b/service.yaml
@@ -8,6 +8,10 @@ Parameters:
     Type: String
     Description: Tag of the Docker Image.
     Default: IMAGE_TAG
+  ContainerPort:
+    Type: Number
+    Default: 9000
+    Description: What port number the application inside the docker container is binding to
   EnvironmentName:
     Type: String
     Description: Name of the Environment.
@@ -61,7 +65,7 @@ Resources:
               Ref: AWS::Region
             awslogs-stream-prefix: !Sub "${EnvironmentName}-APP_NAME"
         PortMappings:
-        - ContainerPort: 9000
+        - ContainerPort: !Ref 'ContainerPort'
         Environment:
         - Name: XXXAWS_XRAY_DAEMON_ADDRESS
           Value: 'xraydaemon:2000'
@@ -165,6 +169,9 @@ ENVIRONMENT_VARIABLES
             Resource: '*'
       Roles:
       - Ref: ECSServiceRole
+  # The service. The service is a resource which allows you to run multiple
+  # copies of a type of task, and gather up their logs and metrics, as well
+  # as monitor the number of running tasks and replace any that have crashed
   Service:
     Type: AWS::ECS::Service
     DependsOn:
@@ -176,20 +183,16 @@ ENVIRONMENT_VARIABLES
         Fn::ImportValue:
           Fn::Sub: "${EnvironmentName}-ECSCluster"
       DesiredCount: DESIRED_COUNT
-      TaskDefinition:
-        Ref: TaskDefinition
+      TaskDefinition: !Ref: TaskDefinition
       LoadBalancers:
       - ContainerName: APP_NAME
-        ContainerPort: 9000
-        TargetGroupArn:
-          Ref: TargetGroup
+        ContainerPort: !Ref 'ContainerPort'
+        TargetGroupArn: !Ref: TargetGroup
       NetworkConfiguration:
         AwsvpcConfiguration:
           Subnets:
-            - Fn::ImportValue:
-                Fn::Sub: "${EnvironmentName}-PrivateSubnet1"
-            - Fn::ImportValue:
-                Fn::Sub: "${EnvironmentName}-PrivateSubnet2"
+            - Fn::ImportValue: Fn::Sub: "${EnvironmentName}-PrivateSubnet1"
+            - Fn::ImportValue: Fn::Sub: "${EnvironmentName}-PrivateSubnet2"
   ApiGateway:
     Type: AWS::ApiGateway::RestApi
     Condition: IsApiGatewayNeeded

--- a/service.yaml
+++ b/service.yaml
@@ -133,7 +133,7 @@ ENVIRONMENT_VARIABLES
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     DependsOn: ALB
     Properties:
-      Name: !Sub "${EnvironmentName}-APP_NAME1"
+      Name: !Sub "${EnvironmentName}-APP_NAME"
       HealthCheckIntervalSeconds: 10
       HealthCheckPath: /health
       HealthCheckProtocol: HTTP

--- a/service.yaml
+++ b/service.yaml
@@ -176,7 +176,8 @@ ENVIRONMENT_VARIABLES
       - ALB
       - ALBListener
     Properties:
-      Cluster: Fn::ImportValue: !Sub '${EnvironmentName}-ECSCluster'
+      Cluster:
+        Fn::ImportValue: !Sub '${EnvironmentName}-ECSCluster'
       DesiredCount: DESIRED_COUNT
       TaskDefinition: !Ref 'TaskDefinition'
       LoadBalancers:

--- a/service.yaml
+++ b/service.yaml
@@ -185,7 +185,7 @@ ENVIRONMENT_VARIABLES
           TargetGroupArn: !Ref 'TargetGroup'
       NetworkConfiguration:
         AwsvpcConfiguration:
-          SecurityGroup:
+          SecurityGroups:
             - Fn::ImportValue: !Sub '${EnvironmentName}-ECSHostSecurityGroup'
           Subnets:
             - Fn::ImportValue: !Sub '${EnvironmentName}-PrivateSubnet1'

--- a/service.yaml
+++ b/service.yaml
@@ -133,7 +133,7 @@ ENVIRONMENT_VARIABLES
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     DependsOn: ALB
     Properties:
-      Name: !Sub "${EnvironmentName}-APP_NAME"
+      Name: !Sub "${EnvironmentName}-APP_NAME1"
       HealthCheckIntervalSeconds: 10
       HealthCheckPath: /health
       HealthCheckProtocol: HTTP


### PR DESCRIPTION
Replace bridge Network Mode with awsvpc to handle a noisy neighbor issue. 
Because of the bridge mode, the task utilizes Docker's built-in virtual network which runs inside each container instance.